### PR TITLE
removed pr0texter.com

### DIFF
--- a/usi-hosts.txt
+++ b/usi-hosts.txt
@@ -3699,7 +3699,6 @@ pornoskraft.com
 portrayart.com
 potentialfinancialfreedom-blog-ifyoutakeaction.com
 potshow.net
-pr0texter.com
 pramlog.com
 prccollege.com
 preciouspetsdeliveryservice.com


### PR DESCRIPTION
pr0texter.com is a website which helps creating and styling posts (in form of images) for the imageboard and online community pr0gramm.com